### PR TITLE
Move fetching logic out of clients, into fetchFiles

### DIFF
--- a/controllers/bucket_fetch_test.go
+++ b/controllers/bucket_fetch_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+)
+
+type mockBucketClient struct {
+	bucketName string
+	objects    map[string]string
+}
+
+var mockNotFound = fmt.Errorf("not found")
+
+func (m mockBucketClient) BucketExists(c context.Context, name string) (bool, error) {
+	return name == m.bucketName, nil
+}
+
+func (m mockBucketClient) ObjectExists(c context.Context, bucket, obj string) (bool, error) {
+	if bucket != m.bucketName {
+		return false, fmt.Errorf("bucket does not exist")
+	}
+	_, ok := m.objects[obj]
+	return ok, nil
+}
+
+func (m mockBucketClient) FGetObject(c context.Context, bucket, obj, path string) error {
+	if bucket != m.bucketName {
+		return fmt.Errorf("bucket does not exist")
+	}
+	// tiny bit of protocol, for convenience: if asked for an object "error", then return an error.
+	if obj == "error" {
+		return fmt.Errorf("I was asked to report an error")
+	}
+	object, ok := m.objects[obj]
+	if !ok {
+		return mockNotFound
+	}
+	return os.WriteFile(path, []byte(object), os.FileMode(0660))
+}
+
+func (m mockBucketClient) ObjectIsNotFound(e error) bool {
+	return e == mockNotFound
+}
+
+func (m mockBucketClient) VisitObjects(c context.Context, bucket string, f func(string) error) error {
+	for path := range m.objects {
+		if err := f(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m mockBucketClient) Close(c context.Context) {
+	return
+}
+
+// Since the algorithm for fetching files uses concurrency and has some complications around error
+// reporting, it's worth testing by itself.
+func TestFetchFiles(t *testing.T) {
+	files := map[string]string{
+		"foo.yaml": "foo: 1",
+		"bar.yaml": "bar: 2",
+		"baz.yaml": "baz: 3",
+	}
+	bucketName := "all-my-config"
+
+	bucket := sourcev1.Bucket{
+		Spec: sourcev1.BucketSpec{
+			BucketName: bucketName,
+			Timeout:    &metav1.Duration{Duration: 1 * time.Hour},
+		},
+	}
+	client := mockBucketClient{
+		objects:    files,
+		bucketName: bucketName,
+	}
+
+	t.Run("fetch files happy path", func(t *testing.T) {
+		tmp, err := os.MkdirTemp("", "test-bucket")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmp)
+
+		_, err = fetchFiles(context.TODO(), client, bucket, tmp)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for path := range files {
+			p := filepath.Join(tmp, path)
+			_, err := os.Stat(p)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	})
+
+	t.Run("an error while fetching returns an error for the whole procedure", func(t *testing.T) {
+		tmp, err := os.MkdirTemp("", "test-bucket")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmp)
+
+		files["error"] = "this one causes an error"
+		_, err = fetchFiles(context.TODO(), client, bucket, tmp)
+		if err == nil {
+			t.Fatal("expected error but got nil")
+		}
+	})
+
+	t.Run("can fetch more than maxConcurrentFetches", func(t *testing.T) {
+		// this will fail if, for example, the semaphore is not used correctly and blocks
+		tmp, err := os.MkdirTemp("", "test-bucket")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmp)
+
+		lotsOfFiles := map[string]string{}
+		for i := 0; i < 2*maxConcurrentFetches; i++ {
+			f := fmt.Sprintf("file-%d", i)
+			lotsOfFiles[f] = f
+		}
+		lotsOfFilesClient := mockBucketClient{
+			bucketName: bucketName,
+			objects:    lotsOfFiles,
+		}
+
+		_, err = fetchFiles(context.TODO(), lotsOfFilesClient, bucket, tmp)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -22,15 +22,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	gcpstorage "cloud.google.com/go/storage"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
-	"github.com/fluxcd/source-controller/pkg/sourceignore"
-	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/go-logr/logr"
-
-	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	corev1 "k8s.io/api/core/v1"
@@ -178,10 +173,8 @@ func (c *GCPClient) FGetObject(ctx context.Context, bucketName, objectName, loca
 // ListObjects lists the objects/contents of the bucket whose bucket name is provided.
 // the objects are returned as an Objectiterator and .Next() has to be called on them
 // to loop through the Objects. The Object are downloaded using a goroutine.
-func (c *GCPClient) ListObjects(ctx context.Context, matcher gitignore.Matcher, bucketName, tempDir string) error {
-	log := logr.FromContext(ctx)
+func (c *GCPClient) VisitObjects(ctx context.Context, bucketName string, visit func(string) error) error {
 	items := c.Client.Bucket(bucketName).Objects(ctx, nil)
-	g, ctxx := errgroup.WithContext(ctx)
 	for {
 		object, err := items.Next()
 		if err == IteratorDone {
@@ -191,18 +184,9 @@ func (c *GCPClient) ListObjects(ctx context.Context, matcher gitignore.Matcher, 
 			err = fmt.Errorf("listing objects from bucket '%s' failed: %w", bucketName, err)
 			return err
 		}
-		if !(strings.HasSuffix(object.Name, "/") || object.Name == sourceignore.IgnoreFile || matcher.Match(strings.Split(object.Name, "/"), false)) {
-			g.Go(func() error {
-				if err := DownloadObject(ctxx, c, object, matcher, bucketName, tempDir); err != nil {
-					log.Error(err, fmt.Sprintf("Error downloading %s from bucket %s: ", object.Name, bucketName))
-					return err
-				}
-				return nil
-			})
+		if err = visit(object.Name); err != nil {
+			return err
 		}
-	}
-	if err := g.Wait(); err != nil {
-		return err
 	}
 	return nil
 }
@@ -218,13 +202,4 @@ func (c *GCPClient) Close(ctx context.Context) {
 // ObjectIsNotFound checks if the error provided is ErrorObjectDoesNotExist(object does not exist)
 func (c *GCPClient) ObjectIsNotFound(err error) bool {
 	return errors.Is(err, ErrorObjectDoesNotExist)
-}
-
-// DownloadObject gets an object and downloads the object locally.
-func DownloadObject(ctx context.Context, cl *GCPClient, obj *gcpstorage.ObjectAttrs, matcher gitignore.Matcher, bucketName, tempDir string) error {
-	localPath := filepath.Join(tempDir, obj.Name)
-	if err := cl.FGetObject(ctx, bucketName, obj.Name, localPath); err != nil {
-		return err
-	}
-	return nil
 }

--- a/pkg/gcp/gcp_test.go
+++ b/pkg/gcp/gcp_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 	"github.com/fluxcd/source-controller/pkg/gcp"
-	"github.com/fluxcd/source-controller/pkg/sourceignore"
 	"google.golang.org/api/googleapi"
 	raw "google.golang.org/api/storage/v1"
 	"gotest.tools/assert"
@@ -174,7 +173,6 @@ func TestNewClientWithSecretErr(t *testing.T) {
 
 func TestNewClientWithoutSecretErr(t *testing.T) {
 	gcpClient, err := gcp.NewClient(context.Background(), badSecret, bucketNoSecretRef)
-	t.Log(err)
 	assert.NilError(t, err)
 	assert.Assert(t, gcpClient != nil)
 }
@@ -220,36 +218,28 @@ func TestObjectNotExists(t *testing.T) {
 	assert.Assert(t, !exists)
 }
 
-func TestListObjects(t *testing.T) {
+func TestVisitObjects(t *testing.T) {
 	gcpClient := &gcp.GCPClient{
 		Client: client,
 	}
-	tempDir, err := os.MkdirTemp("", bucketName)
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
-	path := filepath.Join(tempDir, sourceignore.IgnoreFile)
-	ps, err := sourceignore.ReadIgnoreFile(path, nil)
-	assert.NilError(t, err)
-	matcher := sourceignore.NewMatcher(ps)
 
-	err = gcpClient.ListObjects(context.Background(), matcher, bucketName, tempDir)
+	objs := []string{}
+	err := gcpClient.VisitObjects(context.Background(), bucketName, func(path string) error {
+		objs = append(objs, path)
+		return nil
+	})
 	assert.NilError(t, err)
+	assert.DeepEqual(t, objs, []string{})
 }
 
-func TestListObjectsErr(t *testing.T) {
+func TestVisitObjectsErr(t *testing.T) {
 	gcpClient := &gcp.GCPClient{
 		Client: client,
 	}
 	badBucketName := "bad-bucket"
-	tempDir, err := os.MkdirTemp("", badBucketName)
-	defer os.RemoveAll(tempDir)
-	assert.NilError(t, err)
-	path := filepath.Join(tempDir, sourceignore.IgnoreFile)
-	ps, err := sourceignore.ReadIgnoreFile(path, nil)
-	assert.NilError(t, err)
-	matcher := sourceignore.NewMatcher(ps)
-
-	err = gcpClient.ListObjects(context.Background(), matcher, badBucketName, tempDir)
+	err := gcpClient.VisitObjects(context.Background(), badBucketName, func(path string) error {
+		return nil
+	})
 	assert.Error(t, err, fmt.Sprintf("listing objects from bucket '%s' failed: storage: bucket doesn't exist", badBucketName))
 }
 
@@ -293,46 +283,6 @@ func TestFGetObjectDirectoryIsFileName(t *testing.T) {
 	if err != io.EOF {
 		assert.Error(t, err, "filename is a directory")
 	}
-}
-
-func TestDownloadObject(t *testing.T) {
-	gcpClient := &gcp.GCPClient{
-		Client: client,
-	}
-	tempDir, err := os.MkdirTemp("", bucketName)
-	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
-	path := filepath.Join(tempDir, sourceignore.IgnoreFile)
-	ps, err := sourceignore.ReadIgnoreFile(path, nil)
-	assert.NilError(t, err)
-	matcher := sourceignore.NewMatcher(ps)
-	err = gcp.DownloadObject(context.Background(), gcpClient, &gcpstorage.ObjectAttrs{
-		Bucket:      bucketName,
-		Name:        objectName,
-		ContentType: "text/x-yaml",
-		Size:        1 << 20,
-	}, matcher, bucketName, tempDir)
-	assert.NilError(t, err)
-}
-
-func TestDownloadObjectErr(t *testing.T) {
-	gcpClient := &gcp.GCPClient{
-		Client: client,
-	}
-	tempDir, err := os.MkdirTemp("", bucketName)
-	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
-	path := filepath.Join(tempDir, sourceignore.IgnoreFile)
-	ps, err := sourceignore.ReadIgnoreFile(path, nil)
-	assert.NilError(t, err)
-	matcher := sourceignore.NewMatcher(ps)
-	err = gcp.DownloadObject(context.Background(), gcpClient, &gcpstorage.ObjectAttrs{
-		Bucket:      bucketName,
-		Name:        "test1.yaml",
-		ContentType: "text/x-yaml",
-		Size:        1 << 20,
-	}, matcher, bucketName, tempDir)
-	assert.Error(t, err, "storage: object doesn't exist")
 }
 
 func TestValidateSecret(t *testing.T) {

--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -188,30 +188,23 @@ func TestFGetObject(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestListObjects(t *testing.T) {
+func TestVisitObjects(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := os.MkdirTemp("", bucketName)
+	objs := []string{}
+	err := minioclient.VisitObjects(ctx, bucketName, func(path string) error {
+		objs = append(objs, path)
+		return nil
+	})
 	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
-	path := filepath.Join(tempDir, sourceignore.IgnoreFile)
-	ps, err := sourceignore.ReadIgnoreFile(path, nil)
-	assert.NilError(t, err)
-	matcher := sourceignore.NewMatcher(ps)
-	err = minioclient.ListObjects(ctx, matcher, bucketName, tempDir)
-	assert.NilError(t, err)
+	assert.DeepEqual(t, objs, []string{})
 }
 
-func TestListObjectsErr(t *testing.T) {
+func TestVisitObjectsErr(t *testing.T) {
 	ctx := context.Background()
 	badBucketName := "bad-bucket"
-	tempDir, err := os.MkdirTemp("", bucketName)
-	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
-	path := filepath.Join(tempDir, sourceignore.IgnoreFile)
-	ps, err := sourceignore.ReadIgnoreFile(path, nil)
-	assert.NilError(t, err)
-	matcher := sourceignore.NewMatcher(ps)
-	err = minioclient.ListObjects(ctx, matcher, badBucketName, tempDir)
+	err := minioclient.VisitObjects(ctx, badBucketName, func(string) error {
+		return nil
+	})
 	assert.Error(t, err, fmt.Sprintf("listing objects from bucket '%s' failed: The specified bucket does not exist", badBucketName))
 }
 


### PR DESCRIPTION
The logic for which files to fetch is common to the client implementations. This PR moves that logic, and the code for fetching concurrently, to `fetchFiles`. The client implementations only have to enumerate the objects in the bucket, so that `fetchFiles` can pick which to download.